### PR TITLE
Update to Chisel 6.7, use new annotation API

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -15,9 +15,9 @@ import $file.dependencies.chisel.build
 import $file.common
 
 object v {
-  val scala = "2.13.12"
+  val scala = "2.13.16"
   val chiselCrossVersions = Map(
-    "6.1.0" -> (ivy"org.chipsalliance::chisel:6.1.0", ivy"org.chipsalliance:::chisel-plugin:6.1.0"),
+    "6.7.0" -> (ivy"org.chipsalliance::chisel:6.7.0", ivy"org.chipsalliance:::chisel-plugin:6.7.0"),
     // build from project from source
     "source" -> (ivy"org.chipsalliance::chisel:99", ivy"org.chipsalliance:::chisel-plugin:99"),
   )

--- a/diplomacy/src/diplomacy/lazymodule/LazyModuleImp.scala
+++ b/diplomacy/src/diplomacy/lazymodule/LazyModuleImp.scala
@@ -1,8 +1,7 @@
 package org.chipsalliance.diplomacy.lazymodule
 
 import chisel3.{withClockAndReset, Module, RawModule, Reset, _}
-import chisel3.experimental.{ChiselAnnotation, CloneModuleAsRecord, SourceInfo}
-import firrtl.passes.InlineAnnotation
+import chisel3.experimental.{CloneModuleAsRecord, SourceInfo}
 import org.chipsalliance.cde.config.Parameters
 import org.chipsalliance.diplomacy.nodes.Dangle
 
@@ -120,9 +119,7 @@ sealed trait LazyModuleImpLike extends RawModule {
     }
 
     if (wrapper.shouldBeInlined) {
-      chisel3.experimental.annotate(new ChiselAnnotation {
-        def toFirrtl = InlineAnnotation(toNamed)
-      })
+      chisel3.experimental.annotate(this)(Seq(firrtl.passes.InlineAnnotation(toNamed)))
     }
 
     // Return [[IO]] and [[Dangle]] of this [[LazyModuleImp]].


### PR DESCRIPTION
The `ChiselAnnotation` API is going away in Chisel 7. This API was introduced in https://github.com/chipsalliance/chisel/pull/4643 and was released in Chisel 6.7.0.

Resolves #18.